### PR TITLE
Deprecate Action Package [major]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 # wipac-dev-flake8-action
 
-The WIPAC Dev Team's GitHub Action Package for Running Flake8
+## _Deprecated as of March 2026_
 
-## Overview
+This action package has been deprecated. Please use the reusable workflow `WIPACrepo/wipac-dev-workflows/.github/workflows/lint-python.yml@...` instead.
 
-This is a simple GitHub Action package that runs flake8 with several standardized options (commandline arguments). See `action.yml` for more detail.
-
-Additional options can be given in the usual flake8 config file [locations](https://flake8.pycqa.org/en/latest/user/configuration.html).
+For more information, see:
+https://github.com/WIPACrepo/wipac-dev-workflows/tree/main/.github/workflows/lint-python.md

--- a/README.md
+++ b/README.md
@@ -6,3 +6,5 @@ This action package has been deprecated. Please use the reusable workflow `WIPAC
 
 For more information, see:
 https://github.com/WIPACrepo/wipac-dev-workflows/tree/main/.github/workflows/lint-python.md
+
+This repository previously provided the WIPAC Dev Team's GitHub Action package for running Flake8 with standardized options.

--- a/action.yml
+++ b/action.yml
@@ -1,15 +1,17 @@
-name: 'DEPRECATED: WIPAC Dev Flake8'
-description: 'DEPRECATED: GitHub Action Package for Running Flake8'
+name: 'Deprecated: WIPAC Dev Flake8'
+description: 'Deprecated GitHub Action for running Flake8'
 
 runs:
   using: "composite"
   steps:
-    - name: DEPRECATED
+    - name: Deprecated
       run: |
-        # step: DEPRECATED
+        # step: Deprecated
         set -euo pipefail
-        echo "::error::This action is deprecated."
-        echo "::notice::Please use the WIPACrepo/wipac-dev-workflows/.github/workflows/lint-python.yml@...' reusable workflow instead."
-        echo "::notice::See https://github.com/WIPACrepo/wipac-dev-workflows/tree/main/.github/workflows/lint-python.md for more information."
+
+        echo "::error::This action has been deprecated and can no longer be used."
+        echo "::notice::Use the reusable workflow 'WIPACrepo/wipac-dev-workflows/.github/workflows/lint-python.yml@<ref>' instead."
+        echo "::notice::See https://github.com/WIPACrepo/wipac-dev-workflows/tree/main/.github/workflows/lint-python.md for details."
+
         exit 1
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,16 @@
 name: 'Deprecated: WIPAC Dev Flake8'
 description: 'Deprecated GitHub Action for running Flake8'
 
+inputs:
+  max-function-length:
+    description: 'The max number of logical lines of code per function'
+    required: false
+    default: '200'
+  max-complexity:
+    description: 'The max allowed McCabe complexity value per function (1-5: simple; 6-10: readable; 11-15: harder to read; >15: potentially hard to maintain)'
+    required: false
+    default: '15'
+
 runs:
   using: "composite"
   steps:

--- a/action.yml
+++ b/action.yml
@@ -1,80 +1,15 @@
-name: 'WIPAC Dev Flake8'
-description: 'GitHub Action Package for Running Flake8'
-
-inputs:
-  max-function-length:
-    description: 'The max number of logical lines of code per function'
-    required: false
-    default: '200'
-  max-complexity:
-    description: 'The max allowed McCabe complexity value per function (1-5: simple; 6-10: readable; 11-15: harder to read; >15: potentially hard to maintain)'
-    required: false
-    default: '15'
+name: 'DEPRECATED: WIPAC Dev Flake8'
+description: 'DEPRECATED: GitHub Action Package for Running Flake8'
 
 runs:
   using: "composite"
   steps:
-    - run: |
+    - name: DEPRECATED
+      run: |
+        # step: DEPRECATED
         set -euo pipefail
-        echo "now: $(date -u +"%Y-%m-%dT%H:%M:%S.%3N")"
-        pip install --upgrade pip
-        pip install flake8
-        pip install flake8-max-function-length
-      shell: bash
-    - run: |
-        set -euo pipefail
-        echo "now: $(date -u +"%Y-%m-%dT%H:%M:%S.%3N")"
-        echo "Running Flake8..."
-        
-        FLAKE8_FAILED=false
-        
-        # Start building Flake8 args
-        FLAKE8_ARGS=(".")
-        FLAKE8_ARGS+=("--max-function-length=${{ inputs.max-function-length }}")
-        FLAKE8_ARGS+=("--max-complexity=${{ inputs.max-complexity }}")
-        FLAKE8_ARGS+=("--benchmark")
-        FLAKE8_ARGS+=("--verbose")
-        
-        # Force config file if found
-        if [ -f .flake8 ]; then
-          echo "Using .flake8 config file"
-          FLAKE8_ARGS+=("--config=.flake8")
-        elif [ -f setup.cfg ] && grep -q '^\s*\[flake8\]' setup.cfg; then
-          FLAKE8_ARGS+=("--config=setup.cfg")
-        elif [ -f tox.ini ] && grep -q '^\s*\[flake8\]' tox.ini; then
-          FLAKE8_ARGS+=("--config=tox.ini")
-        else
-          echo "No Flake8 config found. Appending default ignore list"
-          FLAKE8_ARGS+=("--ignore=E203,E226,E228,E231,E501,W503,W504")
-        fi
-        
-        # run!
-        echo "flake8 ${FLAKE8_ARGS[*]}"
-        if ! flake8 "${FLAKE8_ARGS[@]}" | tee flake8_output.log; then
-          FLAKE8_FAILED=true
-        fi
-        
-        # put in env var to interpret downstream
-        echo "FLAKE8_FAILED=$FLAKE8_FAILED" >> "$GITHUB_ENV"
-      shell: bash
-    - run: |
-        set -euo pipefail
-        echo "now: $(date -u +"%Y-%m-%dT%H:%M:%S.%3N")"
-        EXIT_WITH=0
-
-        if grep -q "is too complex" flake8_output.log; then
-          echo "::error::Complexity issues detected. Refactor or adjust 'max-complexity'."
-          EXIT_WITH=1
-        fi
-        if grep -q "Function too long" flake8_output.log; then
-          echo "::error::Function length issues detected. Refactor or adjust 'max-function-length'."
-          EXIT_WITH=1
-        fi
-        # Check the exported FLAKE8_FAILED variable
-        if [ "${FLAKE8_FAILED:-false}" = "true" ]; then
-          echo "::error::Flake8 found code style errors. Check the output above for details."
-          EXIT_WITH=1
-        fi
-
-        exit $EXIT_WITH
+        echo "::error::This action is deprecated."
+        echo "::notice::Please use the WIPACrepo/wipac-dev-workflows/.github/workflows/lint-python.yml@...' reusable workflow instead."
+        echo "::notice::See https://github.com/WIPACrepo/wipac-dev-workflows/tree/main/.github/workflows/lint-python.md for more information."
+        exit 1
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,7 @@ runs:
         # step: Deprecated
         set -euo pipefail
 
-        echo "::error::This action has been deprecated and can no longer be used."
+        echo "::error::This action has been deprecated and can no longer be used (see below)."
         echo "::notice::Use the reusable workflow 'WIPACrepo/wipac-dev-workflows/.github/workflows/lint-python.yml@<ref>' instead."
         echo "::notice::See https://github.com/WIPACrepo/wipac-dev-workflows/tree/main/.github/workflows/lint-python.md for details."
 


### PR DESCRIPTION
_All good things must come to an end. Farewell Flake8._ :wave:

</br>

As detailed in the README:
> This action package has been deprecated. Please use the reusable workflow `WIPACrepo/wipac-dev-workflows/.github/workflows/lint-python.yml@...` instead.
> 
> For more information, see:
https://github.com/WIPACrepo/wipac-dev-workflows/tree/main/.github/workflows/lint-python.md

A similar message is printed when the action is run, followed by an `exit 1`.

